### PR TITLE
Install missing color scheme

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -297,6 +297,13 @@ install_youcompleteme() {
   fi
 }
 
+install_vim_color_scheme() {
+  mkdir -p ~/.vim/colors
+  pushd ~/.vim/colors
+  wget https://raw.githubusercontent.com/tomasr/molokai/master/colors/molokai.vim
+  popd
+}
+
 stage "Creating linked config files" true
 parse_folder link "${REPO}/link"
 
@@ -308,6 +315,9 @@ install_youcompleteme
 
 stage "Installing vundle"
 install_vundle
+
+stage "Installing vim color scheme"
+install_vim_color_scheme
 
 stage "Running post install scripts"
 parse_folder conditionally_exec "post_install"


### PR DESCRIPTION
After running the existing dotfiles INSTALL script from scratch, there's
an error upon opening vim:

Error detected while processing /home/${USER}/.vimrc:
line   44:
E185: Cannot find color scheme 'molokai'

This commit modifies the INSTALL script to download that color scheme.
